### PR TITLE
fix: amend spelling errors in customer service readme

### DIFF
--- a/agents/customer-service/README.md
+++ b/agents/customer-service/README.md
@@ -26,7 +26,7 @@ The agent is built using a multi-modal architecture, combining text and video in
 
 It is important to notice that this agent is not integrated to an actual backend and the behaviour is based on mocked tools. If you would like to implement this agent with actual backend integration you will need to edit [customer_service/tools.py](./customer_service/tools/tools.py)
 
-Because the tools are mocked you might notice that some reuqested changes will not be applied. For instance newly added item to cart will not show if later a user asks the agent to list all items.
+Because the tools are mocked you might notice that some requested changes will not be applied. For instance newly added item to cart will not show if later a user asks the agent to list all items.
 
 ### Key Features
 
@@ -137,7 +137,7 @@ The agent has access to the following tools:
     - Set the `GOOGLE_GENAI_USE_VERTEXAI`, `GOOGLE_CLOUD_PROJECT`, and `GOOGLE_CLOUD_LOCATION` environment variables. You can set them in your `.env` file (modify and rename .env_sample file to .env) or directly in your shell. Alternatively you can edit [customer_service/config.py](./customer_service/config.py)
 
     ```bash
-    export GOOGLE_CLOUD_PROJECT=YOUR_ROJECT_NAME_HERE
+    export GOOGLE_CLOUD_PROJECT=YOUR_PROJECT_NAME_HERE
     export GOOGLE_GENAI_USE_VERTEXAI=1
     export GOOGLE_CLOUD_LOCATION=us-central1
     ```
@@ -242,7 +242,7 @@ In order to inherit all dependencies of your agent you can build the wheel file 
     ```
 
 1.  **Deploy the agent to agents engine**
-    It is importand to run deploy.py from withing deployment folder so paths are correct
+    It is important to run deploy.py from within deployment folder so paths are correct
 
     ```bash
     cd deployment
@@ -267,7 +267,7 @@ vertexai.init(
 )
 
 # get the agent based on resource id
-agent_engine = vertexai.agent_engines.get('DEPLOYMENT_RESOURSE_NAME') # looks like this projects/PROJECT_ID/locations/LOCATION/reasoningEngines/REASONING_ENGINE_ID
+agent_engine = vertexai.agent_engines.get('DEPLOYMENT_RESOURCE_NAME') # looks like this projects/PROJECT_ID/locations/LOCATION/reasoningEngines/REASONING_ENGINE_ID
 
 for event in remote_agent.stream_query(
     user_id=USER_ID,


### PR DESCRIPTION
This PR amends several spelling errors found in the customer service readme file.

```
```